### PR TITLE
Remove debug prints and re-enable all test cases in test_file_input_stream.cpp

### DIFF
--- a/src/sak/file_input_stream.cpp
+++ b/src/sak/file_input_stream.cpp
@@ -31,7 +31,6 @@
 
 namespace sak
 {
-
     file_input_stream::file_input_stream()
         : m_filesize(0)
     {
@@ -43,7 +42,6 @@ namespace sak
         open(filename);
     }
 
-
     void file_input_stream::open(const std::string& filename)
     {
         assert(!m_file.is_open());
@@ -51,15 +49,11 @@ namespace sak
         boost::system::error_code ec;
         open(filename, ec);
 
-        // If an error throw
-        std::cout << "before throw" << std::endl;
-        if(ec)
+        // If an error occurs, throw that
+        if (ec)
         {
-            boost::system::system_error e(ec);
-            std::cout << "right before throw" << std::endl;
-            throw e;
+            error::throw_error(ec);
         }
-        // error::throw_error(ec);
     }
 
     void file_input_stream::open(const std::string& filename,
@@ -108,12 +102,12 @@ namespace sak
     {
         assert(m_file.is_open());
 
-        // Work around for problem on iOS where tellg returned -1 when
+        // Workaround for problem on iOS where tellg returned -1 when
         // reading the last byte. However the EOF flag was correctly
-        // set. So here we check for EOF if true we set the
+        // set. So here we check for EOF, if it is true we set the
         // read_position = m_file_size
 
-        if(m_file.eof())
+        if (m_file.eof())
         {
             return m_filesize;
         }
@@ -148,5 +142,4 @@ namespace sak
         assert(m_file.is_open());
         return m_filesize;
     }
-
 }

--- a/test/src/test_file_input_stream.cpp
+++ b/test/src/test_file_input_stream.cpp
@@ -100,48 +100,26 @@ TEST(TestFileInputStream, ReadRandomFile)
     EXPECT_EQ(0, std::remove(file_name.c_str()));
 }
 
-#if defined(__EXCEPTIONS)
-
 /// Tests error handling with exception
-TEST(TestFileInputStream, ExceptionThrow)
+TEST(TestFileInputStream, ThrowExceptionInOpen)
 {
-
     sak::file_input_stream fs;
     boost::system::error_code ec;
 
-    std::cout << "Excpetions defined" << std::endl;
-
-#ifdef __GLIBCPP__
-    std::printf("GLIBCPP: %d\n",__GLIBCPP__);
-#endif
-#if (defined(__GLIBCXX__) && !BOOST_PP_IS_EMPTY(__GLIBCXX__))
-    std::printf("GLIBCXX: %d\n",__GLIBCXX__);
-#endif
-
     try
     {
-        std::cout << "before open" << std::endl;
         fs.open("strange_file_that_should_not_exist.notfound");
-        std::cout << "after open" << std::endl;
     }
     catch (const boost::system::system_error& error)
     {
-        std::cout << "In catch" << std::endl;
         ec = error.code();
-    }
-    catch (...)
-    {
-        std::cout << "Catch default" << std::endl;
     }
 
     EXPECT_EQ(ec, sak::error::failed_open_file);
-
 }
 
-#endif
-
 /// Tests error handling with exception
-TEST(TestFileInputStream, ExceptionReturn)
+TEST(TestFileInputStream, ReturnErrorCode)
 {
 
     sak::file_input_stream fs;
@@ -152,24 +130,21 @@ TEST(TestFileInputStream, ExceptionReturn)
     EXPECT_EQ(ec, sak::error::failed_open_file);
 
 }
-//
-// /// Tests error handling with exception in constructor
-// TEST(TestFileInputStream, ExceptionThrowConstructor)
-// {
-//
-//
-//     boost::system::error_code ec;
-//
-//     try
-//     {
-//         sak::file_input_stream fs(
-//             "strange_file_that_should_not_exist.notfound");
-//     }
-//     catch (const boost::system::system_error& error)
-//     {
-//         ec = error.code();
-//     }
-//
-//     EXPECT_EQ(ec, sak::error::failed_open_file);
-//
-// }
+
+/// Tests error handling with exception in constructor
+TEST(TestFileInputStream, ThrowExceptionInConstructor)
+{
+    boost::system::error_code ec;
+
+    try
+    {
+        sak::file_input_stream fs(
+            "strange_file_that_should_not_exist.notfound");
+    }
+    catch (const boost::system::system_error& error)
+    {
+        ec = error.code();
+    }
+
+    EXPECT_EQ(ec, sak::error::failed_open_file);
+}


### PR DESCRIPTION
@mortenvp @jpihl I found a solution for this OpenWrt problem: adding `conf.env['STLIB'] += ['gcc_eh']` to the mkspec produces a binary which has all the C++ libraries statically linked. Now the exceptions work on both the VM and the Laguna board.
So I removed the debug prints, and I merge this branch to run a dependency check with the new mkspecs.
